### PR TITLE
Fixed missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,13 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "MDAnalysis>=2.6.1",
+    "shapely>=2.0.2",
+    "scipy>=1.12.0",
+    "ipython>=8.0"
 ]
 keywords = [
     "molecular simulations",
+    
 ]
 dynamic = [
     "version",
@@ -32,8 +36,7 @@ test = [
     "pytest>=6.0",
     "pytest-xdist>=2.5",
     "pytest-cov>=3.0",
-    "shapely>=2.0.2",
-    "scipy>=1.12.0"
+    
 ]
 doc = [
     "sphinx",


### PR DESCRIPTION


Fixes [#](https://github.com/Becksteinlab/Protein_Area/issues/8#issue-3815863658)

Fixed missing dependency in the pyproject.toml
Now pip install correctly installs shapely and ipython

Changes made in this Pull Request:
 - Added shapely>=2.0.2 and ipython>=8.0 to pyproject.toml dependencies.
 - Locally tested installation on workstations.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
